### PR TITLE
Handle bug when destroy assignments

### DIFF
--- a/frontend/src/javascripts/components/molecules/meteorite.tsx
+++ b/frontend/src/javascripts/components/molecules/meteorite.tsx
@@ -64,6 +64,10 @@ class Meteorite extends React.Component<MeteoriteProps, {}> {
         ? `planet-${selectedAssignments[0]}`
         : `project-${selectedProject[0]}`
     const targetDom: any = document.getElementById(targetIdName) // should be div.id="planet-2-Earth" class="planet-medium-secundus"
+    if (!targetDom) {
+      this.showErrorFlash('Sorry, something went wrong. Please reload and try again...')
+      return
+    }
 
     // 要素の位置座標を取得.
     const clientRectMov: any = movDom.getBoundingClientRect()

--- a/frontend/src/javascripts/components/molecules/missile.tsx
+++ b/frontend/src/javascripts/components/molecules/missile.tsx
@@ -64,6 +64,10 @@ class Missle extends React.Component<MissleProps, {}> {
         ? `planet-${selectedAssignments[0]}`
         : `project-${selectedProject[0]}`
     const targetDom: any = document.getElementById(targetIdName) // should be div.id="planet-2-Earth" class="planet-medium-secundus"
+    if (!targetDom) {
+      this.showErrorFlash('Sorry, something went wrong. Please reload and try again...')
+      return
+    }
 
     // 要素の位置座標を取得.
     const clientRectMov: any = movDom.getBoundingClientRect()


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
targetDomがnullの時にバグが発生して画面がまっさらになってしまうので、根本的解決とはいきませんが、次善策として、エラーが発生したことをユーザーに通知するようにしました。
<img width="1440" alt="2019-02-23 21 15 02" src="https://user-images.githubusercontent.com/39128496/53286350-89f7c900-37b0-11e9-9ba1-cb986c3e359e.png">

## 関連Issue
resolve #184 
## 詳細

## 対象ページ

## TodoList

## 特にレビューしてほしいところ

## その他
